### PR TITLE
Fix a bug happening with long words

### DIFF
--- a/lib/trie.js
+++ b/lib/trie.js
@@ -60,7 +60,7 @@ function Trie() {
 
 			if (node.value) path[length++] = node.value;
 
-			if (node.isLeaf) result.push(prefix + path.join(""));
+			if (node.isLeaf) result.push(prefix + path.slice(0, length).join(""));
 
 			if (limit && result.length >= limit) return;
 			

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "autocompletor",
+  "name": "autocompletor_a",
   "description": "A utility for autocompleting words using in memory trie data structure",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": [
     "trie",
     "autocomplete"


### PR DESCRIPTION
The traversed word path is not handled properly if long words and short words are interweaved.

The result before the fix:

> [
>   "book-learning",
>   "book-lorening",
>   "book-plateing",
>   "book-shelfing"
> ]

The result after the fix: 

> [
>   "book-learning",
>   "book-lore",
>   "book-plate",
>   "book-shelf"
> ]
